### PR TITLE
implement the "tasks.matrix" syntax

### DIFF
--- a/examples/manifest/benchmark_loop/.gitignore
+++ b/examples/manifest/benchmark_loop/.gitignore
@@ -1,0 +1,1 @@
+reports/

--- a/examples/manifest/benchmark_loop/Project.toml
+++ b/examples/manifest/benchmark_loop/Project.toml
@@ -1,0 +1,6 @@
+[deps]
+BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
+CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"
+DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
+JSON3 = "0f8b85d8-7281-11e9-16c2-39a750bddbf1"
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/examples/manifest/benchmark_loop/benchmark.toml
+++ b/examples/manifest/benchmark_loop/benchmark.toml
@@ -1,0 +1,69 @@
+version = "0.1"
+dialect = "manifest"
+
+order = [["julia_init", "python_init"], ["julia_benchmark", "numpy_benchmark"], ["summary"]]
+
+[[tasks]]
+    name = "Initialize julia dependencies"
+    id = "julia_init"
+    runner = "shell"
+    [tasks.run]
+        command = "julia --startup=no --project=. -e 'using Pkg; Pkg.instantiate()'"
+        enable_stderr = false
+        enable_stdout = false
+
+[[tasks]]
+    name = "Initialize python dependencies"
+    id = "python_init"
+    runner = "shell"
+    [tasks.run]
+        command = "pip install numpy -q"
+        enable_stderr = false
+        enable_stdout = false
+
+[[tasks]]
+    name = "basic"
+    id = "julia_benchmark"
+    groups = ["Type:LinearAlgebra", "Type:Benchmark", "Framework:Julia"]
+    deps = ["scripts/julia"]
+    runner = "shell"
+    [tasks.matrix]
+        script = ["rand.jl", "sum.jl"]
+        length = ["64", "128", "256", "512", "1024", "2048", "4096"]
+        [[tasks.matrix.includes]]
+            script = "sum.jl"
+            length = "8192"
+        [[tasks.matrix.excludes]]
+            script = "rand.jl"
+            length = "4096"
+    [tasks.run]
+        command = "julia --startup=no --project=. scripts/julia/${{ matrix.script }} ${{ matrix.length }}"
+        capture = true
+
+[[tasks]]
+    name = "basic"
+    id = "numpy_benchmark"
+    groups = ["Type:LinearAlgebra", "Type:Benchmark", "Framework:Numpy"]
+    deps = ["scripts/python"]
+    runner = "shell"
+    [tasks.matrix]
+        script = ["randn.py", "sum.py"]
+        length = ["64", "128", "256", "512", "1024", "2048"]
+        [[tasks.matrix.includes]]
+            script = "randn.py"
+            length = 32
+        [[tasks.matrix.includes]]
+            script = "sum.py"
+            length = 4096
+    [tasks.run]
+        command = "python scripts/numpy/${{ matrix.script }} ${{ matrix.length }}"
+        capture = true
+
+[[tasks]]
+    name = "summary"
+    id = "summary"
+    groups = ["Type:LinearAlgebra", "Type:Benchmark"]
+    deps = ["summary.jl", "@__STDOUT__julia_benchmark", "@__STDOUT__numpy_benchmark"]
+    outs = ["reports"]
+    runner = "shell"
+    run = { command = "julia --startup=no --project=. summary.jl" }

--- a/examples/manifest/benchmark_loop/scripts/julia/rand.jl
+++ b/examples/manifest/benchmark_loop/scripts/julia/rand.jl
@@ -1,0 +1,15 @@
+using LinearAlgebra
+using BenchmarkTools
+using JSON3
+include(joinpath(@__DIR__, "utils.jl"))
+
+n = parse(Int, ARGS[1])
+
+b = @benchmark rand($n) samples=100 evals=1
+
+rst = trial_to_dict(b)
+rst["size"] = n
+rst["name"] = "rand"
+rst["framework"] = "julia"
+
+JSON3.write(stdout, rst)

--- a/examples/manifest/benchmark_loop/scripts/julia/sum.jl
+++ b/examples/manifest/benchmark_loop/scripts/julia/sum.jl
@@ -1,0 +1,16 @@
+using LinearAlgebra
+using BenchmarkTools
+using JSON3
+include(joinpath(@__DIR__, "utils.jl"))
+
+n = parse(Int, ARGS[1])
+
+x = rand(n)
+b = @benchmark sum($x) samples=100 evals=1
+
+rst = trial_to_dict(b)
+rst["size"] = n
+rst["name"] = "sum"
+rst["framework"] = "julia"
+
+JSON3.write(stdout, rst)

--- a/examples/manifest/benchmark_loop/scripts/julia/utils.jl
+++ b/examples/manifest/benchmark_loop/scripts/julia/utils.jl
@@ -1,0 +1,10 @@
+using BenchmarkTools
+
+function trial_to_dict(trial::BenchmarkTools.Trial)
+    d = Dict{String, Any}()
+    d["time"] = mean(trial.times)
+    d["gctimes"] = mean(trial.gctimes)
+    d["allocs"] = trial.allocs
+    d["memory"] = trial.memory
+    return d
+end

--- a/examples/manifest/benchmark_loop/scripts/numpy/randn.py
+++ b/examples/manifest/benchmark_loop/scripts/numpy/randn.py
@@ -1,0 +1,14 @@
+import numpy as np
+import json
+from utils import belapsed
+import sys
+
+n = int(sys.argv[1])
+rst = {
+    "time": belapsed(lambda: np.random.rand(n), number=100),
+    "name": "randn",
+    "size": n,
+    "framework": "numpy",
+}
+
+print(json.dumps(rst))

--- a/examples/manifest/benchmark_loop/scripts/numpy/sum.py
+++ b/examples/manifest/benchmark_loop/scripts/numpy/sum.py
@@ -1,0 +1,15 @@
+import numpy as np
+import json
+from utils import belapsed
+import sys
+
+n = int(sys.argv[1])
+x = np.random.rand(n)
+rst = {
+    "time": belapsed(lambda: x.sum(), number=100),
+    "name": "sum",
+    "size": n,
+    "framework": "numpy",
+}
+
+print(json.dumps(rst))

--- a/examples/manifest/benchmark_loop/scripts/numpy/utils.py
+++ b/examples/manifest/benchmark_loop/scripts/numpy/utils.py
@@ -1,0 +1,10 @@
+import timeit
+
+
+def belapsed(func, *, number=None):
+    if number:
+        return timeit.timeit(func, number=number) / number
+    else:
+        timer = timeit.Timer(func)
+        n, t = timer.autorange()
+        return t / n

--- a/examples/manifest/benchmark_loop/summary.jl
+++ b/examples/manifest/benchmark_loop/summary.jl
@@ -1,0 +1,21 @@
+src_file = get(ENV, "WORKFLOW_TMP_INFILE", "")
+@assert isfile(src_file) "file $src_file not existed"
+
+using JSON3
+using DataFrames
+using CSV
+
+data = open(src_file) do io
+    JSON3.read(io)
+end
+
+dfs = map(collect(keys(data))) do tid
+    DataFrame(JSON3.read.(data[tid]))
+end
+
+df = reduce(dfs) do X, Y
+    outerjoin(X, Y; on=intersect(names(X), names(Y)), matchmissing=:equal)
+end
+
+mkpath("reports")
+CSV.write("reports/results.csv", df)

--- a/src/Workflows.jl
+++ b/src/Workflows.jl
@@ -12,4 +12,12 @@ include("runners/Runners.jl")
 using .Runners: execute_task
 include("scheduler.jl")
 
+
+"""
+Interfaces:
+
+- [`Workflows.execute`](@ref)
+"""
+Workflows
+
 end

--- a/src/dialects/Dialects.jl
+++ b/src/dialects/Dialects.jl
@@ -17,6 +17,7 @@ abstract type AbstractExecutionOrder end
 
 include("traits.jl")
 include("orders.jl")
+include("simpletask.jl")
 include("manifest.jl")
 include("utils.jl")
 include("config_io.jl")

--- a/src/dialects/Dialects.jl
+++ b/src/dialects/Dialects.jl
@@ -18,6 +18,7 @@ abstract type AbstractExecutionOrder end
 include("traits.jl")
 include("orders.jl")
 include("simpletask.jl")
+include("looptask.jl")
 include("manifest.jl")
 include("utils.jl")
 include("config_io.jl")

--- a/src/dialects/looptask.jl
+++ b/src/dialects/looptask.jl
@@ -1,0 +1,22 @@
+@option struct LoopTask <: AbstractTask
+    name::String
+    id::String
+    runner::String
+    groups::Vector{String} = String[]
+    deps::Vector{String} = String[]
+    outs::Vector{String} = String[]
+    matrix::Dict{String} = Dict{String,Any}()
+    run::Dict{String, Any} = Dict{String, Any}()
+end
+
+task_id(t::LoopTask) = t.id
+task_name(t::LoopTask) = t.name
+task_groups(t::LoopTask) = t.groups
+task_deps(t::LoopTask) = t.deps
+task_outs(t::LoopTask) = t.outs
+runner_type(t::LoopTask) = t.runner
+runner_info(::LoopTask) = error("LoopTask must be unrolled first to get runner information")
+
+function Base.show(io::IO, t::LoopTask)
+    print(io, "LoopTask(name=\"", task_name(t), "\", id=\"", task_id(t), "\")")
+end

--- a/src/dialects/looptask.jl
+++ b/src/dialects/looptask.jl
@@ -20,3 +20,73 @@ runner_info(::LoopTask) = error("LoopTask must be unrolled first to get runner i
 function Base.show(io::IO, t::LoopTask)
     print(io, "LoopTask(name=\"", task_name(t), "\", id=\"", task_id(t), "\")")
 end
+
+function Base.collect(t::LoopTask)
+    special_names = ("includes", "excludes")
+    matrix_keys = [k for k in keys(t.matrix) if !in(k, special_names)]
+    excludes = get(t.matrix, "excludes", Dict{String,Any}[])
+    excludes = [Dict("matrix.$k"=>v for (k, v) in patterns) for patterns in excludes]
+    includes = get(t.matrix, "includes", Dict{String,Any}[])
+    includes = [Dict("matrix.$k"=>v for (k, v) in patterns) for patterns in includes]
+
+    function _build_task(t, patterns; count::Int)
+        config = Dict{String,Any}()
+        config["name"] = t.name
+        config["runner"] = t.runner
+        config["groups"] = t.groups
+        config["deps"] = t.deps
+        config["outs"] = t.outs
+        config["id"] = t.id * "@$count"
+        config["run"] = render(t.run, patterns)
+        return from_dict(SimpleTask, config)
+    end
+
+    items = SimpleTask[]
+    patterns = Dict{String, String}()
+    id_count = 1
+    for v in Base.Iterators.product(getindex.(Ref(t.matrix), matrix_keys)...)
+        for (i, k) in enumerate(matrix_keys)
+            patterns["matrix.$k"] = string(v[i])
+        end
+        patterns in excludes && continue
+        push!(items, _build_task(t, patterns; count=id_count))
+        id_count += 1
+    end
+    for patterns in includes
+        push!(items, _build_task(t, patterns; count=id_count))
+        id_count += 1
+    end
+
+    return items
+end
+
+"""
+    render(old, patterns::Dict) -> new
+
+Recursively render strings in `old` by substituting `patterns`.
+
+```jldoctest; setup=:(using Workflows.Dialects: render)
+julia> render("echo \${{ greet }}, \${{ name }}", Dict("greet"=>"hello", "name"=>"world"))
+"echo hello, world"
+
+julia> render("echo \${{ values }}", Dict("values" => "[1, 2, 3]"))
+"echo [1, 2, 3]"
+```
+"""
+function render(config::Dict{String}, patterns::Dict)
+    out = Dict{String,Any}()
+    for (k, old) in config
+        out[k] = render(old, patterns)
+    end
+    return out
+end
+render(contents::Vector{String}, patterns) = map(v->render(v, patterns), contents)
+
+function render(content::String, patterns::Dict)
+    build_regex(name, value) = r"\${{\s*" * name * r"\s*}}" => value
+
+    # TODO(johnnychen94): tweak the performance of `replace`
+    out = replace(content, (build_regex(k, v) for (k, v) in patterns)...)
+    return out
+end
+render(x::Number, patterns) = x

--- a/src/dialects/looptask.jl
+++ b/src/dialects/looptask.jl
@@ -86,7 +86,15 @@ function render(content::String, patterns::Dict)
     build_regex(name, value) = r"\${{\s*" * name * r"\s*}}" => value
 
     # TODO(johnnychen94): tweak the performance of `replace`
-    out = replace(content, (build_regex(k, v) for (k, v) in patterns)...)
+    out = _replace(content, (build_regex(k, v) for (k, v) in patterns)...)
     return out
 end
 render(x::Number, patterns) = x
+
+@static if VERSION < v"1.7"
+    # slooooow version
+    _replace(s, pat1, pat2...; kwargs...) = _replace(_replace(s, pat1; kwargs...), pat2...; kwargs...)
+    _replace(s, pat1; kwargs...) = replace(s, pat1; kwargs...)
+else
+    _replace(s, pat...; kwargs...) = replace(s, pat...; kwargs...)
+end

--- a/src/dialects/manifest.jl
+++ b/src/dialects/manifest.jl
@@ -46,7 +46,11 @@ function from_dict(::Type{ManifestWorkflow}, ::OptionField{:tasks}, ::Type{Dict{
         end
         throw(ArgumentError("duplicate tasks detected: $(collect(ids))."))
     end
-    return Dict(t["id"]=>from_dict(SimpleTask, t) for t in tasks)
+    function _build_task(config)
+        T = haskey(config, "matrix") ? LoopTask : SimpleTask
+        from_dict(T, config)
+    end
+    return Dict(t["id"]=>_build_task(t) for t in tasks)
 end
 
 function to_dict(::Type{ManifestWorkflow}, tasks::Dict{String,AbstractTask}, option::Configurations.ToDictOption)

--- a/src/dialects/manifest.jl
+++ b/src/dialects/manifest.jl
@@ -1,20 +1,3 @@
-@option struct SimpleTask <: AbstractTask
-    name::String
-    id::String
-    groups::Vector{String} = String[]
-    deps::Vector{String} = String[]
-    outs::Vector{String} = String[]
-    runner::String # TODO(johnnychen94): verify runner type
-    run::Dict{String, Any} = Dict{String, Any}()
-end
-task_id(t::SimpleTask) = t.id
-task_name(t::SimpleTask) = t.name
-task_groups(t::SimpleTask) = t.groups
-task_deps(t::SimpleTask) = t.deps
-task_outs(t::SimpleTask) = t.outs
-runner_type(t::SimpleTask) = t.runner
-runner_info(t::SimpleTask) = t.run
-
 @option struct ManifestWorkflow <: AbstractWorkflow
     version::VersionNumber
     dialect::String = "manifest"

--- a/src/dialects/simpletask.jl
+++ b/src/dialects/simpletask.jl
@@ -1,0 +1,16 @@
+@option struct SimpleTask <: AbstractTask
+    name::String
+    id::String
+    groups::Vector{String} = String[]
+    deps::Vector{String} = String[]
+    outs::Vector{String} = String[]
+    runner::String # TODO(johnnychen94): verify runner type
+    run::Dict{String, Any} = Dict{String, Any}()
+end
+task_id(t::SimpleTask) = t.id
+task_name(t::SimpleTask) = t.name
+task_groups(t::SimpleTask) = t.groups
+task_deps(t::SimpleTask) = t.deps
+task_outs(t::SimpleTask) = t.outs
+runner_type(t::SimpleTask) = t.runner
+runner_info(t::SimpleTask) = t.run

--- a/src/dialects/simpletask.jl
+++ b/src/dialects/simpletask.jl
@@ -14,3 +14,12 @@ task_deps(t::SimpleTask) = t.deps
 task_outs(t::SimpleTask) = t.outs
 runner_type(t::SimpleTask) = t.runner
 runner_info(t::SimpleTask) = t.run
+
+function Base.show(io::IO, t::SimpleTask)
+    print(io,
+        "SimpleTask(name=\"", t.name,
+        "\", id=\"", t.id,
+        "\", runner=\"", t.runner,
+        "\")"
+    )
+end

--- a/src/runners/Runners.jl
+++ b/src/runners/Runners.jl
@@ -1,7 +1,7 @@
 module Runners
 
 using Configurations
-using ..Dialects: AbstractTask
+using ..Dialects: AbstractTask, LoopTask
 using ..Dialects: task_id, task_name, task_groups, task_deps, task_outs
 using ..Dialects: runner_type, runner_info
 
@@ -14,6 +14,12 @@ Execute task `t` using runner `exec` in folder `workdir`.
 """
 execute_task(task::AbstractTask; kwargs...) = execute_task(build_runner(task), task; kwargs...)
 execute_task(r::RT, t::AbstractTask; kwargs...) where RT<:AbstractTaskRunner = error("Not implemented for runner type: $RT.")
+
+function execute_task(task::LoopTask; kwargs...)
+    map(collect(task)) do t
+        execute_task(t; kwargs...)
+    end
+end
 
 """
     build_runner(t::AbstractTask)

--- a/src/runners/juliamodule.jl
+++ b/src/runners/juliamodule.jl
@@ -21,9 +21,10 @@ function execute_task(exec::JuliaModuleRunner, t::AbstractTask; workdir::String=
         @debug "Executing task $(task_id(t)) in julia module" workdir=pwd() script
         Core.eval(m, :(include(x) = Base.include($m, x)))
         try
-            redirect_stdio(stdout=stdout, stderr=stderr, stdin=devnull) do
+            out = redirect_stdio(stdout=stdout, stderr=stderr, stdin=devnull) do
                 Core.eval(m, :(Base.include($m, $script)))
             end
+            return out
         catch err
             # Unwrap the LoadError due to `include("script.jl")` call so that it looks like
             # a "real" `julia script.jl` process.

--- a/src/scheduler.jl
+++ b/src/scheduler.jl
@@ -21,6 +21,7 @@ function execute(w::ManifestWorkflow; workdir=".", cleanup=false)
     results = Dict{String,Any}() # store the captured stdout result of shell runner
 
     tmpdir = workflow_tmpdir(w; workdir=workdir)
+    # TODO(johnnychen94): support normal/verbose/quite mode
     @info "execute workflow" workdir cleanup tmpdir
     if cleanup
         atexit() do
@@ -42,15 +43,15 @@ function execute(w::ManifestWorkflow; workdir=".", cleanup=false)
 
             # If this task requests STDOUT results from previous tasks, then dump the data
             # as json file and store the file path as environment variable. The task
-            # script/command is resonsible for appropriately handling this.
+            # script/command is responsible for appropriately handling this.
             stdout_deps = _get_stdout_deps(results, t)
             tmpfile = joinpath(tmpdir, "deps_$tid.json")
             env = _dump_stdout_to_temp(tmpfile, stdout_deps; workdir=workdir)
             if !isnothing(env)
-                @info "prepare task $(tid)" tmpfile
+                @info "prepare task: $(tid)" tmpfile
             end
 
-            @info "Executing task $(tid)"
+            @info "Executing task: $(tid)"
             results[taskid] = execute_task(t; workdir=workdir, env=env)
         end
     end

--- a/test/dialects/examples/manifest/good/loop.toml
+++ b/test/dialects/examples/manifest/good/loop.toml
@@ -1,0 +1,23 @@
+version = "0.1"
+dialect = "manifest"
+
+order = ["1", "2"]
+
+[[tasks]]
+    name = "task1"
+    id = "1"
+    runner = "shell"
+    groups = ["A", "B", "C"]
+    [tasks.matrix]
+        a = [1, 4]
+        b = [2, 8, 10]
+    [tasks.run]
+        command = "echo ${{ matrix.a }} ${{ matrix.b }}"
+        capture = true
+
+[[tasks]]
+    name = "task2"
+    id = "2"
+    runner = "juliamodule"
+    [tasks.run]
+        script = "main.jl"

--- a/test/dialects/looptask.jl
+++ b/test/dialects/looptask.jl
@@ -1,0 +1,85 @@
+module LoopTaskTest
+
+using Workflows: load_config
+using Workflows.Dialects: render
+using Workflows.Dialects: LoopTask, SimpleTask
+using Workflows.Dialects: task_id, task_name, task_groups, task_deps, task_outs
+using Workflows.Dialects: runner_type, runner_info
+using Workflows.Runners: execute_task
+using Test
+
+@testset "render" begin
+    @testset "string" begin
+        msg = raw"echo ${{ matrix.greet}}, ${{ matrix.name   }}"
+        patterns = Dict{String,String}()
+
+        # missing patterns is okay
+        patterns["matrix.greet"] = "hello"
+        @test render(msg, patterns) == raw"echo hello, ${{ matrix.name   }}"
+
+        patterns["matrix.name"] = "world"
+        @test render(msg, patterns) == "echo hello, world"
+
+        # extra patterns are ignored
+        patterns["something_else"] = "spam"
+        @test render(msg, patterns) == "echo hello, world"
+
+        # all occurences of the same name are substituted
+        msg = raw"echo ${{ matrix.greet }}, ${{ matrix.name }}, ${{ matrix.greet }}"
+        patterns = Dict("matrix.greet"=>"hello", "matrix.name"=>"world")
+        @test render(msg, patterns) == "echo hello, world, hello"
+    end
+
+    @testset "dict" begin
+        # test nested structures are substituted correctly
+        config = Dict{String, Any}(
+            "x" => raw"${{ x }}",
+            "y" => [raw"${{ y1 }}", raw"${{ y2 }}", raw"${{ x }}"],
+            "z" => Dict(
+                "z1" => raw"${{ z1 }}",
+                "z2" => [raw"${{ z21 }}", ]
+            ),
+        )
+        patterns = Dict(
+            "x" => "value:x",
+            "y1" => "value:y1", # y2 missing
+            "z1" => "value:z1",
+            "z21" => "value:z21",
+        )
+        config_new = render(config, patterns)
+        @test config_new == Dict{String, Any}(
+            "x" => "value:x",
+            "y" => ["value:y1", raw"${{ y2 }}", "value:x"],
+            "z" => Dict(
+                "z1" => "value:z1",
+                "z2" => ["value:z21", ]
+            ),
+        )
+    end
+end
+
+@testset "looptask" begin
+    casedir = joinpath(@__DIR__, "examples", "manifest", "good")
+
+    w = load_config(joinpath(casedir, "loop.toml"))
+    t = w.tasks["1"]
+    @test t isa LoopTask
+    @test task_id(t) == "1"
+    @test task_groups(t) == ["A", "B", "C"]
+    unrolled = collect(t)
+    @test length(unrolled) == 6
+    @test all(t->isa(t, SimpleTask), unrolled)
+    @test all(t->startswith(task_id(t), "1@"), unrolled)
+    @test all(t->runner_type(t) == "shell", unrolled)
+    @test all(t->runner_info(t)["capture"] == true, unrolled)
+    @test all(t->task_groups(t) == ["A", "B", "C"], unrolled)
+    @test runner_info(unrolled[1])["command"] == "echo 1 2"
+    @test runner_info(unrolled[end])["command"] == "echo 4 10"
+
+    # test loop task can be executed correctly
+    rst = execute_task(t)
+    # Although the execution order might be undetermined, the result order should be fixed
+    @test rst == ["1 2", "1 8", "1 10", "4 2", "4 8", "4 10"]
+end
+
+end # module

--- a/test/examples/manifest/loop.toml
+++ b/test/examples/manifest/loop.toml
@@ -1,0 +1,63 @@
+version = "0.1"
+dialect = "manifest"
+
+order = ["init", "sum", "exp", "summary", "report"]
+
+[[tasks]]
+    name = "init"
+    id = "init"
+    runner = "shell"
+    [tasks.run]
+        command = "julia --startup=no --project=. -e 'using Pkg; Pkg.instantiate()'"
+        enable_stderr = false
+        enable_stdout = false
+
+[[tasks]]
+    name = "small sum"
+    id = "sum"
+    groups = ["Package:Base", "Type:Benchmark"]
+    runner = "shell"
+    [tasks.matrix]
+        a = [1, 3, 5]
+        b = [2, 4]
+        [[tasks.matrix.includes]]
+            a = 6
+            b = 10
+        [[tasks.matrix.includes]]
+            a = 2
+            b = 2
+        [[tasks.matrix.excludes]]
+            a = 1
+            b = 2
+    [tasks.run]
+        command = 'julia --startup=no --project=. -e "println(parse(Int, ARGS[1])+parse(Int, ARGS[2]))" ${{matrix.a}} ${{matrix.b}}'
+        capture = true
+
+[[tasks]]
+    name = "exp"
+    id = "exp"
+    groups = ["Package:Base", "Type:Benchmark"]
+    deps = ["scripts"]
+    outs = ["test_outs/exp.json"]
+    runner = "shell"
+    [tasks.run]
+        command = "julia --startup=no --project=. scripts/exp.jl"
+        enable_stderr = false
+        enable_stdout = false
+
+[[tasks]]
+    name = "summary"
+    id = "summary"
+    groups = ["Type:LinearAlgebra", "Type:Benchmark"]
+    deps = ["summary.jl", "@__STDOUT__sum"]
+    outs = ["test_outs/results.json"]
+    runner = "shell"
+    [tasks.run]
+        command = "julia --startup=no --project=. summary.jl"
+
+[[tasks]]
+    name = "print result"
+    id = "report"
+    runner = "shell"
+    [tasks.run]
+        command = "julia --startup=no --project=. print.jl"

--- a/test/examples/manifest/simple.toml
+++ b/test/examples/manifest/simple.toml
@@ -28,7 +28,7 @@ groups = ["Package:LinearAlgebra", "Type:Benchmark"]
 deps = ["scripts"]
 runner = "shell"
 [tasks.run]
-command = "julia --startup=no scripts/large_sum.jl"
+command = "julia --startup=no --project=. scripts/large_sum.jl"
 capture = true
 
 [[tasks]]
@@ -39,7 +39,7 @@ deps = ["scripts"]
 outs = ["test_outs/exp.json"]
 runner = "shell"
 [tasks.run]
-command = "julia --startup=no scripts/exp.jl"
+command = "julia --startup=no --project=. scripts/exp.jl"
 enable_stderr = false
 enable_stdout = false
 
@@ -51,7 +51,7 @@ deps = ["summary.jl", "@__STDOUT__1", "@__STDOUT__2", "test_outs/exp.json"]
 outs = ["test_outs/results.json"]
 runner = "shell"
 [tasks.run]
-command = "julia --startup=no summary.jl"
+command = "julia --startup=no --project=. summary.jl"
 
 [[tasks]]
 name = "print result"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -16,6 +16,7 @@ include("testutils.jl")
     @testset "dialects" begin
         include("dialects/foreign.jl")
         include("dialects/manifest.jl")
+        include("dialects/looptask.jl")
         include("dialects/config_io.jl")
     end
 

--- a/test/scheduler.jl
+++ b/test/scheduler.jl
@@ -22,5 +22,19 @@
             @test issubset([".workflows", "test_outs", "Manifest.toml"], readdir(workdir))
             @test strip(read(joinpath(workdir, "test_outs", "results.json"), String)) == strip(msg)
         end
+
+        with_sandbox(includes=["examples"]) do
+            workdir = joinpath("examples", "manifest")
+
+            filename = joinpath(workdir, "loop.toml")
+            msg = @capture_out @suppress_err Workflows.execute(filename)
+            # msg = @capture_out Workflows.execute(filename) # debug
+            results = @test_nowarn JSON3.read(msg)
+            @test results[:exp] isa Float64
+            @test results[:sum] == ["3", "5", "5", "7", "7", "9", "16", "4"]
+
+            @test issubset([".workflows", "test_outs", "Manifest.toml"], readdir(workdir))
+            @test strip(read(joinpath(workdir, "test_outs", "results.json"), String)) == strip(msg)
+        end
     end
 end


### PR DESCRIPTION
Calling `collect(t::LoopTask)` generates `2*7+1-1 = 14` tasks:

```toml
version = "0.1"
dialect = "manifest"

order = ["1"]

[[tasks]]
    name = "basic"
    id = "1"
    groups = ["Type:LinearAlgebra", "Type:Benchmark", "Framework:Julia"]
    deps = ["scripts/julia"]
    runner = "shell"
    [tasks.matrix]
        script = ["rand.jl", "sum.jl"]
        length = ["64", "128", "256", "512", "1024", "2048", "4096"]
        [[tasks.matrix.includes]]
            script = "sum.jl"
            length = "8192"
        [[tasks.matrix.excludes]]
            script = "rand.jl"
            length = "4096"
    [tasks.run]
        command = "julia --startup=no --project=. scripts/julia/${{ matrix.script }} ${{ matrix.length }}"
        capture = true
```

```julia
julia> map(t->runner_info(t)["command"], collect(w.tasks["1"]))
14-element Vector{String}:
 "julia --startup=no --project=. scripts/julia/rand.jl 64"
 "julia --startup=no --project=. scripts/julia/rand.jl 128"
 "julia --startup=no --project=. scripts/julia/rand.jl 256"
 "julia --startup=no --project=. scripts/julia/rand.jl 512"
 "julia --startup=no --project=. scripts/julia/rand.jl 1024"
 "julia --startup=no --project=. scripts/julia/rand.jl 2048"
 "julia --startup=no --project=. scripts/julia/sum.jl 64"
 "julia --startup=no --project=. scripts/julia/sum.jl 128"
 "julia --startup=no --project=. scripts/julia/sum.jl 256"
 "julia --startup=no --project=. scripts/julia/sum.jl 512"
 "julia --startup=no --project=. scripts/julia/sum.jl 1024"
 "julia --startup=no --project=. scripts/julia/sum.jl 2048"
 "julia --startup=no --project=. scripts/julia/sum.jl 4096"
 "julia --startup=no --project=. scripts/julia/sum.jl 8192"
```

closes #10